### PR TITLE
Fix mTLS message handler

### DIFF
--- a/src/App/Platforms/Android/MainApplication.cs
+++ b/src/App/Platforms/Android/MainApplication.cs
@@ -242,7 +242,7 @@ namespace Bit.Droid
 
             #region Nibblewarden
             ServiceContainer.Register<ICertificateService>("certificateService", new CertificateService());
-            ServiceContainer.Register<IHttpClientHandler>("httpClientHandler", new AndroidHttpsClientHandler());
+            ServiceContainer.Register<IHttpMessageHandler>("httpMessageHandler", new AndroidHttpsClientHandler());
             #endregion
 
             // Push

--- a/src/App/Platforms/Android/Security/AndroidHttpsClientHandler.cs
+++ b/src/App/Platforms/Android/Security/AndroidHttpsClientHandler.cs
@@ -9,7 +9,7 @@ using Xamarin.Android.Net;
 namespace Bit.Droid.Security
 {
     // Tag:Nibblewarden
-    public class AndroidHttpsClientHandler : AndroidClientHandler, IHttpClientHandler
+    public class AndroidHttpsClientHandler : AndroidMessageHandler, IHttpMessageHandler
     {
         private X509CertificateChainSpec ClientCertificate;
 
@@ -18,7 +18,7 @@ namespace Bit.Droid.Security
             ClientCertificate = null;
         }
 
-        public HttpClientHandler AsClientHandler()
+        public HttpMessageHandler AsMessageHandler()
         {
             return this;
         }

--- a/src/Core/Abstractions/IHttpMessageHandler.cs
+++ b/src/Core/Abstractions/IHttpMessageHandler.cs
@@ -3,9 +3,9 @@
 namespace Bit.Core.Abstractions
 {
     // Tag:Nibblewarden
-    public interface IHttpClientHandler
+    public interface IHttpMessageHandler
     {
-        HttpClientHandler AsClientHandler();
+        HttpMessageHandler AsMessageHandler();
 
         void UseClientCertificate(ICertificateChainSpec clientCertificate);
     }

--- a/src/Core/Services/ApiService.cs
+++ b/src/Core/Services/ApiService.cs
@@ -40,8 +40,8 @@ namespace Bit.Core.Services
             string customUserAgent = null)
         {
             #region Nibblewarden
-            _httpClientHandler = ServiceContainer.Resolve<IHttpClientHandler>("httpClientHandler");
-            _httpClient = new HttpClient(_httpClientHandler.AsClientHandler());
+            _httpMessageHandler = ServiceContainer.Resolve<IHttpMessageHandler>("httpMessageHandler");
+            _httpClient = new HttpClient(_httpMessageHandler.AsMessageHandler());
             #endregion
 
             _tokenService = tokenService;
@@ -63,10 +63,10 @@ namespace Bit.Core.Services
         public string EventsBaseUrl { get; set; }
 
         #region Nibblewarden
-        private readonly IHttpClientHandler _httpClientHandler;
+        private readonly IHttpMessageHandler _httpMessageHandler;
         public void UseClientCertificate(ICertificateChainSpec certificateChainSpec)
         {
-            _httpClientHandler.UseClientCertificate(certificateChainSpec);
+            _httpMessageHandler.UseClientCertificate(certificateChainSpec);
         }
         #endregion
 


### PR DESCRIPTION
`AndroidClientHandler` not working anymore and deprecated. Replaced with `AndroidMessageHandler`

Fixes #14 